### PR TITLE
Add lightweight device fingerprinting module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,39 @@
 # fp-py
-A fast, lightweight browser fingerprinting module that is anti-bloat
+A fast, lightweight device fingerprinting module that is anti-bloat.
+
+The library mirrors the goals of `fp-js` but is implemented using only Python's
+standard library—no external dependencies are required. It gathers a selection
+of system attributes—such as CPU details, locale, network information, and
+OS-provided machine identifiers—and hashes them into a stable fingerprint.
+
+## Usage
+
+```python
+import fp
+
+print(fp.fingerprint())
+# Inspect the raw components used for the fingerprint
+print(fp.get_components())
+```
+
+To run from the command line:
+
+```bash
+python -m fp            # print the fingerprint
+python -m fp --components  # inspect the raw data
+```
+
+## Sending fingerprints to a server
+
+The optional `fp.client` helpers can transmit a fingerprint to an HTTP endpoint
+using only the standard library:
+
+```python
+from fp.client import post_fingerprint
+
+resp = post_fingerprint("https://example.com/api/fp")
+print(resp)
+```
+
+You can also retrieve the value directly with `fp.client.get_fingerprint()` if
+you prefer to handle network communication yourself.

--- a/fp/__init__.py
+++ b/fp/__init__.py
@@ -1,0 +1,101 @@
+"""Lightweight device fingerprinting utilities using built-in Python modules.
+
+This module collects a small set of system properties and combines them into a
+stable hash that can be used as a fingerprint. Only standard library modules
+are used to keep the implementation lightweight.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import locale
+import os
+import platform
+import re
+import socket
+import subprocess
+import sys
+import time
+import uuid
+from pathlib import Path
+from typing import Dict
+
+
+def machine_id() -> str:
+    """Attempt to retrieve a stable machine identifier."""
+    if sys.platform.startswith("linux"):
+        for path in ("/etc/machine-id", "/var/lib/dbus/machine-id"):
+            try:
+                return Path(path).read_text().strip()
+            except Exception:
+                pass
+    elif sys.platform == "darwin":
+        try:
+            out = subprocess.check_output(
+                ["ioreg", "-rd1", "-c", "IOPlatformExpertDevice"],
+                stderr=subprocess.DEVNULL,
+            )
+            match = re.search(rb'"IOPlatformUUID" = "([^"]+)"', out)
+            if match:
+                return match.group(1).decode()
+        except Exception:
+            pass
+    elif sys.platform == "win32":
+        try:
+            import winreg
+
+            with winreg.OpenKey(
+                winreg.HKEY_LOCAL_MACHINE, r"SOFTWARE\\Microsoft\\Cryptography"
+            ) as key:
+                return winreg.QueryValueEx(key, "MachineGuid")[0]
+        except Exception:
+            pass
+    return "unknown"
+
+
+def get_components() -> Dict[str, str]:
+    """Return a dictionary with identifying system components."""
+    components = {
+        "system": platform.system(),
+        "release": platform.release(),
+        "version": platform.version(),
+        "machine": platform.machine(),
+        "processor": platform.processor(),
+        "architecture": platform.architecture()[0],
+        "cpu_count": str(os.cpu_count() or "unknown"),
+        "python_version": platform.python_version(),
+        "python_compiler": platform.python_compiler(),
+        "node": platform.node(),
+        "fqdn": socket.getfqdn(),
+        "timezone": time.tzname[0],
+        "machine_id": machine_id(),
+    }
+
+    try:
+        loc = locale.getdefaultlocale()[0]
+    except Exception:
+        loc = None
+    components["locale"] = loc or "unknown"
+
+    try:
+        components["mac"] = format(uuid.getnode(), "012x")
+    except Exception:
+        components["mac"] = "unknown"
+
+    try:
+        components["ip"] = socket.gethostbyname(socket.gethostname())
+    except Exception:
+        components["ip"] = "unknown"
+
+    return components
+
+
+def fingerprint() -> str:
+    """Generate a SHA-256 fingerprint from the collected components."""
+    components = get_components()
+    raw = "|".join(f"{key}:{components[key]}" for key in sorted(components))
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+if __name__ == "__main__":  # pragma: no cover - simple CLI
+    print(fingerprint())

--- a/fp/__main__.py
+++ b/fp/__main__.py
@@ -1,0 +1,26 @@
+"""Command line interface for fp."""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+from . import fingerprint, get_components
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate a device fingerprint")
+    parser.add_argument(
+        "--components",
+        action="store_true",
+        help="print the raw component values instead of the hash",
+    )
+    args = parser.parse_args()
+    if args.components:
+        print(json.dumps(get_components(), indent=2, sort_keys=True))
+    else:
+        print(fingerprint())
+
+
+if __name__ == "__main__":
+    main()

--- a/fp/client.py
+++ b/fp/client.py
@@ -1,0 +1,51 @@
+"""Client-side helpers for fp.
+
+Provides convenience functions to obtain a fingerprint and optionally send it
+via HTTP to a remote endpoint. Only standard library modules are used so the
+module remains lightweight.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.request
+from typing import Any, Dict, Optional
+
+from . import fingerprint
+
+
+def get_fingerprint() -> str:
+    """Return the local machine fingerprint."""
+    return fingerprint()
+
+
+def post_fingerprint(
+    url: str,
+    data: Optional[Dict[str, Any]] = None,
+    headers: Optional[Dict[str, str]] = None,
+    timeout: int = 5,
+) -> Dict[str, Any]:
+    """Send the fingerprint to ``url`` and return the decoded JSON response.
+
+    Parameters
+    ----------
+    url: str
+        Endpoint that accepts a JSON body.
+    data: Optional[Dict[str, Any]]
+        Extra key/value pairs to include in the request body.
+    headers: Optional[Dict[str, str]]
+        Optional HTTP headers. ``{"Content-Type": "application/json"}``
+        is used by default.
+    timeout: int
+        Timeout in seconds for the request; defaults to ``5``.
+    """
+    payload: Dict[str, Any] = {"fingerprint": get_fingerprint()}
+    if data:
+        payload.update(data)
+    req = urllib.request.Request(
+        url,
+        data=json.dumps(payload).encode("utf-8"),
+        headers=headers or {"Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return json.loads(resp.read().decode("utf-8"))


### PR DESCRIPTION
## Summary
- Implement lightweight fingerprint generator using only the Python standard library
- Expose CLI for printing fingerprint or raw component values
- Provide client helper to post fingerprints to HTTP endpoints

## Testing
- `python -m py_compile fp/__init__.py fp/__main__.py fp/client.py`
- `python -m fp`
- `python -m fp --components`
- `python - <<'PY'
import fp.client
print('fingerprint prefix:', fp.client.get_fingerprint()[:8])
PY`
- `python - <<'PY'
from fp.client import post_fingerprint
try:
    resp = post_fingerprint('https://httpbin.org/post')
    print('status:', resp.get('url'))
except Exception as e:
    print('error:', e)
PY` *(fails: <urlopen error Tunnel connection failed: 403 Forbidden>)*