### PR TITLE
Use non-deprecated locale API

### DIFF
--- a/fp/__init__.py
+++ b/fp/__init__.py
@@ -72,7 +72,12 @@ def get_components() -> Dict[str, str]:
     }
 
     try:
-        loc = locale.getdefaultlocale()[0]
+        # Attempt to use the user's default setting for LC_CTYPE
+        try:
+            locale.setlocale(locale.LC_CTYPE, "")
+        except Exception:
+            pass
+        loc = locale.getlocale()[0]
     except Exception:
         loc = None
     components["locale"] = loc or "unknown"


### PR DESCRIPTION
## Summary
- use `locale.setlocale` and `locale.getlocale` instead of deprecated `locale.getdefaultlocale`
- keep "unknown" fallback when locale detection fails

## Testing
- `python -m pytest`